### PR TITLE
fix: language supported files do not have an icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,11 @@
                 "extensions": [
                     ".scad"
                 ],
-                "configuration": "./language-configuration.json"
+                "configuration": "./language-configuration.json",
+                "icon": {
+                    "light": "./media/openscad.svg",
+                    "dark": "./media/openscad.svg"
+                }
             }
         ],
         "snippets": [


### PR DESCRIPTION
Hello!
This is a simple fix that I saw where the files do not have the openSCAD icon displayed, despite the icon being included in the media folder. Thought it would be nice to have as a quick change. 
